### PR TITLE
Rivers fixes

### DIFF
--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -11,9 +11,4 @@ include $(TOP)/configure/CONFIG_APP
 # vxWorks. You must rebuild in the iocBoot directory 
 # before this takes effect.
 #IOCS_APPL_TOP = <the top of the application as seen by the IOC>
-
-ifeq (Darwin, $(OS_CLASS))
-  STATIC_BUILD=NO
-else
-  STATIC_BUILD=YES
-endif
+#

--- a/softGlueApp/src/drvIP_EP201.c
+++ b/softGlueApp/src/drvIP_EP201.c
@@ -97,6 +97,9 @@
 
 */
 
+#ifdef vxWorks
+extern int logMsg(char *fmt, ...);
+#endif
 
 
 /* System includes */
@@ -127,6 +130,8 @@ extern int logMsg(char *fmt, ...);
 #include <asynUInt32Digital.h>
 #include <asynInt32.h>
 #include <epicsInterrupt.h>
+#include <iocsh.h>
+#include <epicsExport.h>
 
 #include "drvIP_EP201.h"
 

--- a/softGlueApp/src/drvIP_EP201.h
+++ b/softGlueApp/src/drvIP_EP201.h
@@ -1,17 +1,5 @@
-/* System includes */
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
-#include <ctype.h>
-
-#ifdef vxWorks
-extern int logMsg(char *fmt, ...);
-#endif
-
 /* EPICS includes */
 #include <epicsTypes.h>
-#include <iocsh.h>
-#include <epicsExport.h>
 
 typedef struct {
 	epicsUInt16 mask;


### PR DESCRIPTION
Remove STATIC_BUILD=YES from configure/CONFIG.  Was causing dynamic builds on Windows in 3.15 to fail.

Clean up include files in header files and C files.
