### PR TITLE
Add Travis CI using ci-scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ci"]
+	path = .ci
+	url = https://github.com/epics-base/ci-scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 env:
   global:
     - SETUP_PATH=.ci
-    - MODULES="sncseq asyn"
+    - MODULES="sncseq ipac asyn"
     - SNCSEQ=R2-2-8
     - ASYN=R4-38
     - IPAC=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,113 @@
+# .travis.xml for use with EPICS Base ci-scripts
+# (see: https://github.com/epics-base/ci-scripts)
+
+language: c
+compiler: gcc
+dist: xenial
+
+# Minimal set of packages needed to compile EPICS Base
+
+cache:
+  directories:
+  - $HOME/.cache
+
+env:
+  global:
+    - SETUP_PATH=.ci
+    - MODULES="sncseq asyn"
+    - SNCSEQ=R2-2-8
+    - ASYN=R4-38
+    - IPAC=master
+
+addons:
+  apt:
+    packages:
+    - libreadline6-dev
+    - libncurses5-dev
+    - perl
+    # for clang compiler
+    - clang
+    # for mingw builds (32bit and 64bit)
+    - g++-mingw-w64-i686
+    - g++-mingw-w64-x86-64
+    # for RTEMS cross builds
+    - qemu-system-x86
+  homebrew:
+    packages:
+    # for all EPICS builds
+    - bash
+    # for the sequencer
+    - re2c
+    update: true
+
+install:
+  - ./.ci/travis/prepare.sh
+
+script:
+  - ./.ci/travis/build.sh
+
+# Build using default gcc for Base branches 7.0 and 3.15
+
+jobs:
+  include:
+
+# Default gcc and clang, static build
+
+  - env: BASE=7.0
+
+  - env: BASE=7.0
+    compiler: clang
+
+  - env: BASE=7.0 STATIC=YES
+
+# Trusty: compiler versions very close to RHEL 7
+
+  - env: BASE=7.0
+    dist: trusty
+
+# Cross-compilations to Windows using MinGW and WINE
+
+  - env: BASE=7.0 WINE=32 TEST=NO STATIC=YES
+    compiler: mingw
+
+  - env: BASE=7.0 WINE=64 TEST=NO STATIC=NO
+    compiler: mingw
+
+# MacOS build
+
+  - env: BASE=7.0
+    os: osx
+    compiler: clang
+
+# Cross-compilation to RTEMS
+
+  - env: BASE=7.0 RTEMS=4.10 ADD_MODULES=ipac
+
+  - env: BASE=7.0 RTEMS=4.9 ADD_MODULES=ipac
+
+# Older Base releases
+
+  - env: BASE=R3.15.7
+
+  - env: BASE=R3.15.7 STATIC=YES
+
+# 3.14.12.2 build fails on newer distributions and doesn't know tapfiles target
+  - env: BASE=R3.14.12.2 TEST=NO
+    dist: trusty
+
+  - env: BASE=R3.14.12.2 STATIC=YES TEST=NO
+    dist: trusty
+
+  - env: BASE=R3.14.12.8
+
+  - env: BASE=R3.14.12.8 STATIC=YES
+
+# Other gcc versions (added as an extra package)
+
+  - env: BASE=7.0
+    compiler: gcc-6
+    addons: { apt: { packages: ["g++-6"], sources: ["ubuntu-toolchain-r-test"] } }
+
+  - env: BASE=7.0
+    compiler: gcc-7
+    addons: { apt: { packages: ["g++-7"], sources: ["ubuntu-toolchain-r-test"] } }


### PR DESCRIPTION
MSI is currently not available for R3.14* jobs. This will be added in a future version of ci-scripts.